### PR TITLE
Fix envelope tracking loop

### DIFF
--- a/examples/fodo/input_fodo_envelope.in
+++ b/examples/fodo/input_fodo_envelope.in
@@ -1,0 +1,59 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 10000
+beam.units = static
+beam.kin_energy = 2.0e3
+beam.charge = 1.0e-9
+beam.particle = electron
+beam.distribution = waterbag
+beam.lambdaX = 3.9984884770e-5
+beam.lambdaY = beam.lambdaX
+beam.lambdaT = 1.0e-3
+beam.lambdaPx = 2.6623538760e-5
+beam.lambdaPy = beam.lambdaPx
+beam.lambdaPt = 2.0e-3
+beam.muxpx = -0.846574929020762
+beam.muypy = -beam.muxpx
+beam.mutpt = 0.0
+
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+lattice.elements = monitor drift1 monitor quad1 monitor drift2 monitor quad2 monitor drift3 monitor
+lattice.nslice = 25
+
+monitor.type = beam_monitor
+monitor.backend = h5
+
+drift1.type = drift
+drift1.ds = 0.25
+
+quad1.type = quad
+quad1.ds = 1.0
+quad1.k = 1.0
+
+drift2.type = drift
+drift2.ds = 0.5
+
+quad2.type = quad
+quad2.ds = 1.0
+quad2.k = -1.0
+
+drift3.type = drift
+drift3.ds = 0.25
+
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.particle_shape = 2
+algo.space_charge = false
+algo.track = "envelope"
+
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.slice_step_diagnostics = true

--- a/src/ImpactX.cpp
+++ b/src/ImpactX.cpp
@@ -352,6 +352,10 @@ namespace impactx {
     {
         // TODO: move whole body out in separate file
 
+        BL_PROFILE("ImpactX::track_envelope");
+
+        //validate();  //double-check what this does
+
         // verbosity
         amrex::ParmParse pp_impactx("impactx");
         int verbose = 1;
@@ -374,9 +378,9 @@ namespace impactx {
         amrex::ParmParse pp_diag("diag");
         bool diag_enable = true;
         pp_diag.queryAdd("enable", diag_enable);
-        //if (verbose > 0) {
-        //    amrex::Print() << " Diagnostics: " << diag_enable << "\n";
-        //}
+        if (verbose > 0) {
+            amrex::Print() << " Diagnostics: " << diag_enable << "\n";
+        }
 
         int file_min_digits = 6;
         if (diag_enable)
@@ -391,40 +395,72 @@ namespace impactx {
 
         }
 
-        // loop over all beamline elements
-        for (auto & element_variant : m_lattice)
-        {
-            // TODO: later on, we can add element slicing and space charge kicking in this loop
-            step++;
+        // periods through the lattice
+        int num_periods = 1;
+        amrex::ParmParse("lattice").queryAddWithParser("periods", num_periods);
 
-            std::visit([&ref, &cm](auto&& element){
-                // push reference particle in global coordinates
-                {
-                    BL_PROFILE("impactx::Push::RefPart");
-                    element(ref);
-                }
+        for (int period=0; period < num_periods; ++period) {
+            // loop over all beamline elements
+            for (auto &element_variant: m_lattice) {
+                // update element edge of the reference particle
+                amr_data->m_particle_container->SetRefParticleEdge();
 
-                // push Covariance Matrix
-                element(cm, ref);
+                // number of slices used for the application of space charge
+                int nslice = 1;
+                amrex::ParticleReal slice_ds; // in meters
+                std::visit([&nslice, &slice_ds](auto &&element) {
+                    nslice = element.nslice();
+                    slice_ds = element.ds() / nslice;
+                }, element_variant);
 
-            }, element_variant);
+                // sub-steps for space charge within the element
+                for (int slice_step = 0; slice_step < nslice; ++slice_step) {
+                    BL_PROFILE("ImpactX::evolve::slice_step");
+                    step++;
+                    if (verbose > 0) {
+                        amrex::Print() << " ++++ Starting step=" << step
+                                       << " slice_step=" << slice_step << "\n";
+                    }
 
-            // slice-step diagnostics
-            bool slice_step_diagnostics = false;
-            pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
+                    std::visit([&ref, &cm](auto&& element){
+                        // push reference particle in global coordinates
+                        {
+                            BL_PROFILE("impactx::Push::RefPart");
+                            element(ref);
+                        }
 
-            if (diag_enable && slice_step_diagnostics) {
-                // print slice step reference particle to file
-                diagnostics::DiagnosticOutput(ref, "diags/ref_particle", step, true);
+                        // push Covariance Matrix
+                        element(cm, ref);
 
-                // print slice step reduced beam characteristics to file
-                diagnostics::DiagnosticOutput(cm, ref, "diags/reduced_beam_characteristics", step, true);
+                    }, element_variant);
 
-            }
+                    // just prints an empty newline at the end of the slice_step
+                    if (verbose > 0) {
+                        amrex::Print() << "\n";
+                    }
 
-            // inputs: unused parameters (e.g. typos) check after step 1 has finished
-            if (!early_params_checked) { early_params_checked = early_param_check(); }
-        }
+                    // slice-step diagnostics
+                    bool slice_step_diagnostics = false;
+                    pp_diag.queryAdd("slice_step_diagnostics", slice_step_diagnostics);
+
+
+                    if (diag_enable && slice_step_diagnostics) {
+                        // print slice step reference particle to file
+                        diagnostics::DiagnosticOutput(ref, "diags/ref_particle", step, true);
+
+                        // print slice step reduced beam characteristics to file
+                        diagnostics::DiagnosticOutput(cm, ref, "diags/reduced_beam_characteristics", step, true);
+
+                    }
+
+                    // inputs: unused parameters (e.g. typos) check after step 1 has finished
+                    if (!early_params_checked) { early_params_checked = early_param_check(); }
+
+                } // end in-element space-charge slice-step loop
+
+            } // end beamline element loop
+
+        } // end periods though the lattice loop
 
         if (diag_enable)
         {
@@ -434,19 +470,10 @@ namespace impactx {
             // print the final values of the reduced beam characteristics
             diagnostics::DiagnosticOutput(cm, ref, "diags/reduced_beam_characteristics_final", step);
 
-            // output particles lost in apertures
-            if (amr_data->m_particles_lost->TotalNumberOfParticles() > 0)
-            {
-                std::string openpmd_backend = "default";
-                pp_diag.queryAdd("backend", openpmd_backend);
-
-                diagnostics::BeamMonitor output_lost("particles_lost", openpmd_backend, "g");
-                output_lost(*amr_data->m_particles_lost, 0, 0);
-                output_lost.finalize();
-            }
         }
 
         // loop over all beamline elements & finalize them
         finalize_elements();
     }
+
 } // namespace impactx


### PR DESCRIPTION
This PR fixes some details of the main tracking loop when algo.track = envelope.

The example `input_fodo_envelope.in` is provided, and works correctly (locally on my MacBook).