### PR TITLE
Add DipEdge support & IOTA example

### DIFF
--- a/examples/iota_lattice/input_iotalattice_envelope.in
+++ b/examples/iota_lattice/input_iotalattice_envelope.in
@@ -1,0 +1,231 @@
+###############################################################################
+# Particle Beam(s)
+###############################################################################
+beam.npart = 10000
+beam.units = static
+beam.kin_energy = 2.5
+beam.charge = 1.0e-9
+beam.particle = proton
+beam.distribution = waterbag
+beam.lambdaX = 1.588960728035e-3
+beam.lambdaY = 2.496625268437e-3
+beam.lambdaT = 1.0e-3
+beam.lambdaPx = 2.8320397837724e-3
+beam.lambdaPy = 1.802433091137e-3
+beam.lambdaPt = 0.0
+beam.muxpx = 0.0
+beam.muypy = 0.0
+beam.mutpt = 0.0
+
+
+###############################################################################
+# Beamline: lattice elements and segments
+###############################################################################
+lattice.periods = 5
+lattice.elements = monitor first_half qe3 second_half monitor
+
+# lines
+first_half.type = line
+first_half.elements = dra1 qa1 dra2 qa2 dra3 qa3 dra4 qa4 dra5                \
+                      edge30 sbend30 edge30 drb1 qb1 drb2 qb2 drb2 qb3        \
+                      drb3 dnll drb3 qb4 drb2 qb5 drb2 qb6 drb4               \
+                      edge60 sbend60 edge60 drc1 qc1 drc2 qc2 drc2 qc3 drc1   \
+                      edge60 sbend60 edge60 drd1 qd1 drd2 qd2 drd3 qd3 drd2 qd4 drd4  \
+                      edge30 sbend30 edge30 dre1 qe1 dre2 qe2 dre3
+
+second_half.type = line
+second_half.reverse = true
+second_half.elements = dra1 qa1 dra2 qa2 dra3 qa3 dra4 qa4 dra5               \
+                       edge30 sbend30 edge30 drb1 qb1 drb2 qb2 drb2 qb3       \
+                       drb3 dnll drb3 qb4 drb2 qb5 drb2 qb6 drb4              \
+                       edge60 sbend60 edge60 drc1 qc1 drc2 qc2 drc2 qc3 drc1  \
+                       edge60 sbend60 edge60 drd1 qd1 drd2 qd2 drd3 qd3 drd2 qd4 drd4  \
+                       edge30 sbend30 edge30 dre1 qe1 dre2 qe2 dre3
+
+# thick element splitting for space charge
+lattice.nslice = 10
+
+
+# Drift elements:
+
+dra1.type = drift
+dra1.ds = 0.9125
+
+dra2.type = drift
+dra2.ds = 0.135
+
+dra3.type = drift
+dra3.ds = 0.725
+
+dra4.type = drift
+dra4.ds = 0.145
+
+dra5.type = drift
+dra5.ds = 0.3405
+
+drb1.type = drift
+drb1.ds = 0.3205
+
+drb2.type = drift
+drb2.ds = 0.14
+
+drb3.type = drift
+drb3.ds = 0.1525
+
+drb4.type = drift
+drb4.ds = 0.31437095
+
+drc1.type = drift
+drc1.ds = 0.42437095
+
+drc2.type = drift
+drc2.ds = 0.355
+
+dnll.type = drift
+dnll.ds = 1.8
+
+drd1.type = drift
+drd1.ds = 0.62437095
+
+drd2.type = drift
+drd2.ds = 0.42
+
+drd3.type = drift
+drd3.ds = 1.625
+
+drd4.type = drift
+drd4.ds = 0.6305
+
+dre1.type = drift
+dre1.ds = 0.5305
+
+dre2.type = drift
+dre2.ds = 1.235
+
+dre3.type = drift
+dre3.ds = 0.8075
+
+
+# Bend elements:
+
+sbend30.type = sbend
+sbend30.ds = 0.4305191429
+sbend30.rc = 0.822230996255981
+
+edge30.type = dipedge
+edge30.psi = 0.0
+edge30.rc = 0.822230996255981
+edge30.g = 0.058
+edge30.K2 = 0.5
+
+sbend60.type = sbend
+sbend60.ds = 0.8092963858
+sbend60.rc = 0.772821121503940
+
+edge60.type = dipedge
+edge60.psi = 0.0
+edge60.rc = 0.772821121503940
+edge60.g = 0.058
+edge60.K2 = 0.5
+
+
+# Quad elements:
+
+qa1.type = quad
+qa1.ds = 0.21
+qa1.k = -8.78017699
+
+qa2.type = quad
+qa2.ds = 0.21
+qa2.k = 13.24451745
+
+qa3.type = quad
+qa3.ds = 0.21
+qa3.k = -13.65151327
+
+qa4.type = quad
+qa4.ds = 0.21
+qa4.k = 19.75138652
+
+qb1.type = quad
+qb1.ds = 0.21
+qb1.k = -10.84199727
+
+qb2.type = quad
+qb2.ds = 0.21
+qb2.k = 16.24844348
+
+qb3.type = quad
+qb3.ds = 0.21
+qb3.k = -8.27411104
+
+qb4.type = quad
+qb4.ds = 0.21
+qb4.k = -7.45719247
+
+qb5.type = quad
+qb5.ds = 0.21
+qb5.k = 14.03362243
+
+qb6.type = quad
+qb6.ds = 0.21
+qb6.k = -12.23595641
+
+qc1.type = quad
+qc1.ds = 0.21
+qc1.k = -13.18863768
+
+qc2.type = quad
+qc2.ds = 0.21
+qc2.k = 11.50601829
+
+qc3.type = quad
+qc3.ds = 0.21
+qc3.k = -11.10445869
+
+qd1.type = quad
+qd1.ds = 0.21
+qd1.k = -6.78179218
+
+qd2.type = quad
+qd2.ds = 0.21
+qd2.k = 5.19026998
+
+qd3.type = quad
+qd3.ds = 0.21
+qd3.k = -5.8586173
+
+qd4.type = quad
+qd4.ds = 0.21
+qd4.k = 4.62460039
+
+qe1.type = quad
+qe1.ds = 0.21
+qe1.k = -4.49607687
+
+qe2.type = quad
+qe2.ds = 0.21
+qe2.k = 6.66737146
+
+qe3.type = quad
+qe3.ds = 0.21
+qe3.k = -6.69148177
+
+# Beam Monitor: Diagnostics
+monitor.type = beam_monitor
+monitor.backend = h5
+monitor.nonlinear_lens_invariants = true
+
+
+###############################################################################
+# Algorithms
+###############################################################################
+algo.particle_shape = 2
+algo.space_charge = false
+algo.track = "envelope"
+
+
+###############################################################################
+# Diagnostics
+###############################################################################
+diag.slice_step_diagnostics = true

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -136,8 +136,26 @@ namespace impactx
         Map6x6
         transport_map ([[maybe_unused]] RefPart const & AMREX_RESTRICT refpart) const
         {
-            throw std::runtime_error(std::string(type) + ": Envelope tracking is not yet implemented!");
-            return Map6x6::Identity();
+            using namespace amrex::literals; // for _rt and _prt
+
+            // initialize linear map matrix elements
+            Map6x6 R = Map6x6::Identity();
+
+            // edge focusing matrix elements (zero gap)
+            amrex::ParticleReal const R21 = std::tan(m_psi)/m_rc;
+            amrex::ParticleReal R43 = -R21;
+            amrex::ParticleReal vf = 0;
+            
+            // first-order effect of nonzero gap
+            vf = (1.0_prt + std::pow(sin(m_psi),2))/(std::pow(cos(m_psi),3));
+            vf *= m_g * m_K2/(std::pow(m_rc,2));
+            R43 += vf;
+         
+            // set non-identity matrix elements
+            R(2,1) = R21;
+            R(4,3) = R43;
+
+            return R;
         }
 
         amrex::ParticleReal m_psi; //! pole face angle in rad

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -147,7 +147,8 @@ namespace impactx
             amrex::ParticleReal vf = 0;
             
             // first-order effect of nonzero gap
-            vf = (1.0_prt + std::pow(sin(m_psi),2))/(std::pow(cos(m_psi),3));
+            auto const [sin_psi, cos_psi] = amrex::Math::sincos(m_psi);
+            vf = (1.0_prt + std::pow(sin_psi, 2))/(std::pow(cos_psi, 3));
             vf *= m_g * m_K2/(std::pow(m_rc,2));
             R43 += vf;
          

--- a/src/particles/elements/DipEdge.H
+++ b/src/particles/elements/DipEdge.H
@@ -148,7 +148,7 @@ namespace impactx
             
             // first-order effect of nonzero gap
             auto const [sin_psi, cos_psi] = amrex::Math::sincos(m_psi);
-            vf = (1.0_prt + std::pow(sin_psi, 2))/(std::pow(cos_psi, 3));
+            vf = (1.0_prt + std::pow(sin_psi, 2)) / std::pow(cos_psi, 3);
             vf *= m_g * m_K2/(std::pow(m_rc,2));
             R43 += vf;
          


### PR DESCRIPTION
Added return of linear map for DipEdge element.

Added envelope tracking for IOTA (bare linear lattice) example.