### PR TITLE
[Enzyme] Remove redundant mode assignment before gradient-free section

### DIFF
--- a/check_k2_zero.py
+++ b/check_k2_zero.py
@@ -10,8 +10,6 @@
 from impactx import my_run
 
 verbose = False
-# mode = "forward"
-mode = "backward"
 inputs_file_beam = "examples/fodo_space_charge/input_fodo_envelope_sc.in"
 
 


### PR DESCRIPTION
References #825. The mode = "backward" assignment on line 10 was immediately overwritten by mode = "gradient-free" before being used, making it dead code.